### PR TITLE
Persist querying through errors & introduce optional start-day offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ cargo install stars-price
 ```
 stars-price 30
 ```
+## 30-day moving average with an offset of 5 days
 
+```
+stars-price 30 5
+```
 ## 7-day moving average
 
 ```


### PR DESCRIPTION
- The script should now insist on querying for the same day in case an error occurs, instead of skipping the day with the error
- The user may provide a second integer argument to start querying from a number of days earlier